### PR TITLE
Allow mounter to work with React 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "eslint-plugin-react": "3.x.x"
   },
   "peerDependencies": {
-    "react": "0.14.x",
-    "react-dom": "0.14.x"
+    "react": "0.14.x || 15.x.x",
+    "react-dom": "0.14.x || 15.x.x"
   },
   "dependencies": {
     "babel-runtime": "6.x.x",


### PR DESCRIPTION
#11

I've tried mounter with React 15 and I've seen no issues.  Should be a quick release for this.
