### PR TITLE
Fixed a bug where root is 'react-root' even though using it 'withOptions' 

### DIFF
--- a/lib/__tests__/index.js
+++ b/lib/__tests__/index.js
@@ -17,8 +17,9 @@ const {
 describe('index', () => {
   describe('withOptions', () => {
     it('should call the given function with options', done => {
-      const fn = (a, options) => {
-        expect(a).to.be.equal('abc');
+      const fn = (layoutClass, regions = {}, options) => {
+        expect(layoutClass).to.be.equal('abc');
+        expect(regions).to.deep.equal({});
         expect(options).to.deep.equal({aa: 10});
         done();
       };

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,9 +12,13 @@ export function mount(layoutClass, regions, options = {}) {
   mounter(layoutClass, regions, options);
 }
 
-export function withOptions(options, fn) {
-  return function (...args) {
-    const newArgs = [ ...args, options ];
+export function withOptions(defaultOptions, fn) {
+  return function (layoutClass, regions, options = {}) {
+    const newArgs = [
+      layoutClass,
+      regions,
+      { ...defaultOptions, ...options }
+    ];
     return fn(...newArgs);
   };
 }


### PR DESCRIPTION
When you create a new mounter with `withOptions` and try to mount something without the regions argument, it would use the options from `withOptions` as the regions and not as the options

This will fix #10 
