### PR TITLE
Support new fork of flow-router-ssr

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -17,13 +17,13 @@ export function mounter(layoutClass, regions, options) {
     throw new Error(error);
   }
 
-  if (!Package['kadira:flow-router-ssr']) {
+  if (!Package['kadira:flow-router-ssr'] && !Package['bensventures:flow-router-ssr']) {
     const error =
       'FlowRouter SSR is required to mount components in the server.';
     throw new Error(error);
   }
 
-  var FlowRouter = Package['kadira:flow-router-ssr'].FlowRouter;
+  var FlowRouter = (Package['bensventures:flow-router-ssr']) ? Package['bensventures:flow-router-ssr'] : Package['kadira:flow-router-ssr'].FlowRouter;
   var ssrContext = FlowRouter.ssrContext.get();
   ssrContext.setHtml(html);
 }


### PR DESCRIPTION
Support new fork of flow-router-ssr for newer meteor versions - old package may cause system failures (https://github.com/meteor/galaxy-seo-package/issues/5)